### PR TITLE
Add function for listing keys and types of CRDTs embedded in a map CRDT

### DIFF
--- a/antidoteclient_test.go
+++ b/antidoteclient_test.go
@@ -386,7 +386,7 @@ func testReadMany(t *testing.T) {
 	fmt.Print(counterVal)
 }
 
-func TestMapListMapEntries(t *testing.T) {
+func TestMapListMapKeys(t *testing.T) {
 	client, err := NewClient(Host{"127.0.0.1", 8087})
 	if err != nil {
 		t.Fatal(err)
@@ -414,27 +414,24 @@ func TestMapListMapEntries(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	entryList, err := mapV.ListMapEntries()
+	keyList := mapV.ListMapKeys()
 	if err != nil {
 		t.Fatal(err)
 	}
-	for _, expected := range []struct {
-		key      []byte
-		crdtType CRDTType
-	}{
+	for _, expected := range []MapEntryKey{
 		{[]byte("counter"), CRDTType_COUNTER},
 		{[]byte("reg"), CRDTType_LWWREG},
 		{[]byte("set"), CRDTType_ORSET},
 	} {
 		found := false
-		for _, entry := range entryList {
-			if bytes.Equal(entry.Key, expected.key) && entry.CrdtType == expected.crdtType {
+		for _, entry := range keyList {
+			if bytes.Equal(entry.Key, expected.Key) && entry.CrdtType == expected.CrdtType {
 				found = true
 				break
 			}
 		}
 		if !found {
-			t.Fatalf("expected value %s not found in result (%s)", expected.key, entryList)
+			t.Fatalf("expected value %s not found in result (%s)", expected.Key, keyList)
 		}
 	}
 }

--- a/antidoteclient_test.go
+++ b/antidoteclient_test.go
@@ -385,3 +385,56 @@ func testReadMany(t *testing.T) {
 
 	fmt.Print(counterVal)
 }
+
+func TestMapListMapEntries(t *testing.T) {
+	client, err := NewClient(Host{"127.0.0.1", 8087})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer client.Close()
+
+	tx, err := client.StartTransaction()
+	if err != nil {
+		t.Fatal(err)
+	}
+	timestamp := time.Now().Unix()
+	bucketname := fmt.Sprintf("bucket%d", timestamp)
+	bucket := Bucket{[]byte(bucketname)}
+	key := Key("keyMap")
+
+	err = bucket.Update(tx, MapUpdate(key,
+		CounterInc(Key("counter"), 13),
+		RegPut(Key("reg"), []byte("Hello World")),
+		SetAdd(Key("set"), []byte("A"), []byte("B"))))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	mapV, err := bucket.ReadMap(tx, key)
+	if err != nil {
+		t.Fatal(err)
+	}
+	entryList, err := mapV.ListMapEntries()
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, expected := range []struct {
+		key      []byte
+		crdtType CRDTType
+	}{
+		{[]byte("counter"), CRDTType_COUNTER},
+		{[]byte("reg"), CRDTType_LWWREG},
+		{[]byte("set"), CRDTType_ORSET},
+	} {
+		found := false
+		for _, entry := range entryList {
+			if bytes.Equal(entry.Key, expected.key) && entry.CrdtType == expected.crdtType {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Fatalf("expected value %s not found in result (%s)", expected.key, entryList)
+		}
+	}
+}

--- a/transactions.go
+++ b/transactions.go
@@ -278,6 +278,24 @@ func (mrr *MapReadResult) Counter(key Key) (val int32, err error) {
 	return 0, fmt.Errorf("counter entry with key '%s' not found", key)
 }
 
+// MapEntry represents the key and type of a map entry (embedded CRDT).
+type MapEntry struct {
+	Key      []byte
+	CrdtType CRDTType
+}
+
+// ListMapEntries gives access to the keys and types of map entries (embedded CRDTs).
+func (mrr *MapReadResult) ListMapEntries() (val []MapEntry, err error) {
+	keyList := make([]MapEntry, len(mrr.mapResp.Entries))
+	for i, me := range mrr.mapResp.Entries {
+		keyList[i] = MapEntry{
+			Key:      me.Key.Key,
+			CrdtType: *me.Key.Type,
+		}
+	}
+	return keyList, nil
+}
+
 // Represents updates that can be converted to top-level updates applicable to a bucket
 // or nested updates applicable to a map
 type UpdateConverter interface {

--- a/transactions.go
+++ b/transactions.go
@@ -278,22 +278,22 @@ func (mrr *MapReadResult) Counter(key Key) (val int32, err error) {
 	return 0, fmt.Errorf("counter entry with key '%s' not found", key)
 }
 
-// MapEntry represents the key and type of a map entry (embedded CRDT).
-type MapEntry struct {
+// MapEntryKey represents the key and type of a map entry (embedded CRDT).
+type MapEntryKey struct {
 	Key      []byte
 	CrdtType CRDTType
 }
 
-// ListMapEntries gives access to the keys and types of map entries (embedded CRDTs).
-func (mrr *MapReadResult) ListMapEntries() (val []MapEntry, err error) {
-	keyList := make([]MapEntry, len(mrr.mapResp.Entries))
+// ListMapKeys gives access to the keys and types of map entries (embedded CRDTs).
+func (mrr *MapReadResult) ListMapKeys() []MapEntryKey {
+	keyList := make([]MapEntryKey, len(mrr.mapResp.Entries))
 	for i, me := range mrr.mapResp.Entries {
-		keyList[i] = MapEntry{
+		keyList[i] = MapEntryKey{
 			Key:      me.Key.Key,
 			CrdtType: *me.Key.Type,
 		}
 	}
-	return keyList, nil
+	return keyList
 }
 
 // Represents updates that can be converted to top-level updates applicable to a bucket


### PR DESCRIPTION
The current implementation allows reading the values of entries (embedded CRDTs) of a map CRDT only when knowing their keys and CRDT types.

Adds a function that lists the keys and types of map CRDT entries. These can be then used to read the values of map entries using the existing functionality.
