### PR TITLE
Don't check for error after ListMapKeys()

### DIFF
--- a/antidoteclient_test.go
+++ b/antidoteclient_test.go
@@ -415,9 +415,6 @@ func TestMapListMapKeys(t *testing.T) {
 		t.Fatal(err)
 	}
 	keyList := mapV.ListMapKeys()
-	if err != nil {
-		t.Fatal(err)
-	}
 	for _, expected := range []MapEntryKey{
 		{[]byte("counter"), CRDTType_COUNTER},
 		{[]byte("reg"), CRDTType_LWWREG},


### PR DESCRIPTION
ListMapKeys() does not return any error, so the one from the previous ReadMap() was being unnecessarily reevaluated.